### PR TITLE
added -XScopedTypeVariables to test.bash

### DIFF
--- a/hs/tests.bash
+++ b/hs/tests.bash
@@ -39,6 +39,7 @@ exit 0
 #> :set prompt "#>\n"
 #> :set -XOverloadedStrings
 #> :set -XNoMonomorphismRestriction
+#> :set -XScopedTypeVariables
 #> :load ./Language/Bash/PrettyPrinter.hs
 #> let start = "\n########!\n"
 #> let end = "\n########-\n"


### PR DESCRIPTION
Fixes this:

Illegal signature in pattern: Identifier
