### PR TITLE
Add eval builtin command

### DIFF
--- a/hs/Language/Bash/PrettyPrinter.hs
+++ b/hs/Language/Bash/PrettyPrinter.hs
@@ -164,6 +164,9 @@ instance (Annotation t) => PP (Statement t) where
                                 [bytes var, "[", bytes key, "]=", bytes val]
     Redirect stmt d fd t    ->  do redirectGrp stmt
                                    word (render_redirect d fd t)
+    EvalCommand es          ->  do hangcat ["eval"]
+                                   _ <- traverse pp es
+                                   outdent
 
 hangcat                      =  hangWord . concat
 

--- a/hs/Language/Bash/Syntax.hs
+++ b/hs/Language/Bash/Syntax.hs
@@ -72,6 +72,7 @@ data Statement t
   | DictUpdate      Identifier          (Expression t)      (Expression t)
   | Redirect        (Annotated t)       Redirection
                     FileDescriptor      (Either (Expression t) FileDescriptor)
+  | EvalCommand     [Expression t]
 deriving instance (Eq t) => Eq (Statement t)
 deriving instance (Ord t) => Ord (Statement t)
 deriving instance (Show t) => Show (Statement t)
@@ -104,6 +105,7 @@ instance Functor Statement where
     ArrayUpdate ident a b   ->  ArrayUpdate ident (f' a) (f' b)
     DictUpdate ident a b    ->  DictUpdate ident (f' a) (f' b)
     Redirect ann r fd chan  ->  Redirect (f' ann) r fd (fmapExprFD chan)
+    EvalCommand es          ->  EvalCommand (fmap f' es)
    where
     f'                       =  fmap f
     fmapExprFD (Left expr)   =  Left (f' expr)
@@ -137,6 +139,7 @@ instance Foldable Statement where
     ArrayUpdate _ a b       ->  f' a `mappend` f' b
     DictUpdate _ a b        ->  f' a `mappend` f' b
     Redirect ann _ _ chan   ->  f' ann `mappend` foldMapExprFD chan
+    EvalCommand es          ->  foldMap f' es
    where
     f'                       =  foldMap f
     foldMapExprFD (Left expr) = f' expr

--- a/hs/bash.cabal
+++ b/hs/bash.cabal
@@ -42,4 +42,4 @@ library
                                 Language.Bash.PrettyPrinter.State
                                 Language.Bash.Annotations
                                 Language.Bash.Lib
-
+  ghc-options                 : -Wincomplete-patterns


### PR DESCRIPTION
We add a constructor `EvalCommand` to the `Statement t` type. This corresponds to the `eval` Bash builtin. 

Apart form syntactically being a command, rather than a substitution, `eval` is notably different from the existing inline evaluation primitives. Those are actually evalutated in a subshell, so cannot have side effects in the calling shell.