### PR TITLE
Extend the Expression type with a constructor for unescaped literals

### DIFF
--- a/hs/Language/Bash/PrettyPrinter.hs
+++ b/hs/Language/Bash/PrettyPrinter.hs
@@ -52,6 +52,7 @@ instance PP FileDescriptor where
   pp (FileDescriptor w)      =  (word . pack . show) w
 instance (Annotation t) => PP (Expression t) where
   pp (Literal lit)           =  word (Esc.bytes lit)
+  pp (UnescapedLiteral u)    =  word u
   pp Asterisk                =  word "*"
   pp QuestionMark            =  word "?"
   pp Tilde                   =  word "~"

--- a/hs/Language/Bash/Syntax.hs
+++ b/hs/Language/Bash/Syntax.hs
@@ -147,6 +147,7 @@ instance Foldable Statement where
     well as eval and process substitution. It is 'Foldable' and a 'Functor'.
  -}
 data Expression t            =  Literal Esc.Bash
+                             |  UnescapedLiteral ByteString
                              |  Asterisk
                              |  QuestionMark
                              |  Tilde
@@ -177,6 +178,7 @@ instance IsString (Expression t) where
 instance Functor Expression where
   fmap f expr                =  case expr of
     Literal esc             ->  Literal esc
+    UnescapedLiteral u      ->  UnescapedLiteral u
     Asterisk                ->  Asterisk
     QuestionMark            ->  QuestionMark
     Tilde                   ->  Tilde
@@ -200,6 +202,7 @@ instance Functor Expression where
 instance Foldable Expression where
   foldMap f expr             =  case expr of
     Literal _               ->  mempty
+    UnescapedLiteral _      ->  mempty
     Asterisk                ->  mempty
     QuestionMark            ->  mempty
     Tilde                   ->  mempty
@@ -457,4 +460,3 @@ instance Foldable Assignment where
    where
     f'                       =  foldMap f
     foldMapPair (x, y)       =  f' x `mappend` f' y
-

--- a/hs/bash.cabal
+++ b/hs/bash.cabal
@@ -43,3 +43,4 @@ library
                                 Language.Bash.Annotations
                                 Language.Bash.Lib
 
+  ghc-options: -Wincomplete-patterns


### PR DESCRIPTION
We add `UnescapedLiteral :: ByteString -> Expression t` as an escape hatch. 

As an example, this is needed to produce this piece of Bash output:
```bash
bar="([name]=Bart [age]=12)"
declare -A foo="$bar"
```
The reason we need the escape hatch here is that the `Dict` constructor of the `Assignment` type imposes too much structure.